### PR TITLE
Added Asset Category for `Trades` and `Portfolio_History`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,23 +40,25 @@ CREATE TABLE accounts (
 );
 
 CREATE TABLE trades (
-    trade_id     SERIAL PRIMARY KEY,
-    trade_type   varchar(50)      NOT NULL,
-    trade_date   DATE DEFAULT CURRENT_DATE,
-    user_id      bigint           NOT NULL,
-    asset_symbol varchar(50)      NOT NULL,
-    asset_name   varchar(50)      NOT NULL,
-    asset_price  NUMERIC(1000, 2) NOT NULL,
-    asset_count  NUMERIC(1000, 2) NOT NULL,
-    total_price  numeric GENERATED ALWAYS AS (asset_price * asset_count) STORED
+    trade_id       SERIAL PRIMARY KEY,
+    trade_type     varchar(50)      NOT NULL,
+    trade_date     DATE DEFAULT CURRENT_DATE,
+    user_id        bigint           NOT NULL,
+    asset_symbol   varchar(50)      NOT NULL,
+    asset_name     varchar(50)      NOT NULL,
+    asset_category varchar(50)      NOT NULL,
+    asset_price    NUMERIC(1000, 2) NOT NULL,
+    asset_count    NUMERIC(1000, 2) NOT NULL,
+    total_price    numeric GENERATED ALWAYS AS (asset_price * asset_count) STORED
 );
 
 CREATE TABLE portfolios (
-    portfolio_id        SERIAL PRIMARY KEY,
-    asset_symbol varchar(50)      NOT NULL,
-    user_id      bigint           NOT NULL,
-    asset_name   varchar(50)      NOT NULL,
-    asset_count  NUMERIC(1000, 2) NOT NULL
+    portfolio_id   SERIAL PRIMARY KEY,
+    asset_symbol   varchar(50)      NOT NULL,
+    user_id        bigint           NOT NULL,
+    asset_name     varchar(50)      NOT NULL,
+    asset_category varchar(50)      NOT NULL,
+    asset_count    NUMERIC(1000, 2) NOT NULL
 );
 
 CREATE TABLE portfolio_history (


### PR DESCRIPTION
Since Apha Vantage has different queries for `stock` and `crypto`, it is required to store `asset category` in order to calculate the net-worth of a user.